### PR TITLE
Remove references to /Users/distiller

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,13 @@ jobs:
   ios:
     macos:
       xcode: "9.0"
-    working_directory: /Users/distiller/project/ios
+    working_directory: ~/project/ios
     environment:
-      FL_OUTPUT_DIR: /Users/distiller/project/output
+      FL_OUTPUT_DIR: ~/project/output
     shell: /bin/bash --login -o pipefail
     steps:
       - checkout:
-          path: /Users/distiller/project
+          path: ~/project
       - run:
           name: Set Ruby Version
           command:  echo "ruby-2.4" > ~/.ruby-version
@@ -51,9 +51,9 @@ jobs:
           command: cp $FL_OUTPUT_DIR/scan/report.junit $FL_OUTPUT_DIR/scan/results.xml
           when: always
       - store_artifacts:
-          path: /Users/distiller/project/output
+          path: ~/project/output
       - store_test_results:
-          path: /Users/distiller/project/output/scan
+          path: ~/project/output/scan
 
 workflows:
   version: 2


### PR DESCRIPTION
In config.yml, some paths use ~ and some others are absolute (with /Users/distiller).

I found it disturbating, that's why I suggest this PR.